### PR TITLE
Added dynamic values for stats and leaderboard

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -6,29 +6,19 @@ import { ThemedView } from '@/components/themed-view';
 import {router} from "expo-router";
 import { useState, useEffect } from 'react';
 
-type LeaderboardEntry = {
-    user: { username: string };
-    bestStreak: number;
-  };
-export default function HomeScreen() {
-  
-  // TODO: replace hardcoded data with fetch from /getLeaderboard when backend is ready
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:8080';
 
-  // const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
-  // useEffect(() => {
-  //   fetch('https://backend-eu81.onrender.com/getLeaderboard')
-  //     .then(res => res.json())
-  //     .then(data => setLeaderboard(data));
-  // }, []);
-  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([
-    { user: { username: "ace_spotter" }, bestStreak: 15 },
-    { user: { username: "planeguy99" }, bestStreak: 12 },
-    { user: { username: "jetfan42" }, bestStreak: 9 },
-    { user: { username: "planeguy94" }, bestStreak: 8 },
-    { user: { username: "jetfan40" }, bestStreak: 4 },
-    { user: { username: "planeguy92" }, bestStreak: 2 },
-    { user: { username: "jetfan38" }, bestStreak: 1 },
-  ]);
+type LeaderboardEntry = {
+    user: { name: string };
+    bestStreak: number;
+};
+export default function HomeScreen() {
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/stats/getLeaderboard`)
+      .then(res => res.json())
+      .then(data => setLeaderboard(data));
+  }, []);
   return (
     <ParallaxScrollView
       headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
@@ -60,7 +50,7 @@ export default function HomeScreen() {
         {leaderboard.map((player, index) => (
           <ThemedView key={index} style={styles.leaderboardRow}>
             <ThemedText>#{index + 1}</ThemedText>
-            <ThemedText>{player.user.username}</ThemedText>
+            <ThemedText>{player.user.name}</ThemedText>
             <ThemedText>{player.bestStreak}</ThemedText>
           </ThemedView>
         ))}

--- a/app/(tabs)/stats.tsx
+++ b/app/(tabs)/stats.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
+import { useAuth } from '../../lib/auth';
 
-const API_BASE_URL = 'https://backend-eu81.onrender.com';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:8080';
 
 type Stats = {
   gamesPlayed: number;
@@ -11,36 +12,28 @@ type Stats = {
 };
 
 export default function StatsScreen() {
-//   const [stats, setStats] = useState<Stats | null>(null);
-//   const [loading, setLoading] = useState(true);
-//   const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { user } = useAuth();
+  const userId = user?.userId;
 
-//   const userId = 1;
-
-//   useEffect(() => {
-//     fetch(`${API_BASE_URL}/stats/getStats?userId=${userId}`)
-//       .then((res) => {
-//         if (!res.ok) throw new Error('Stats not found');
-//         return res.json();
-//       })
-//       .then((data) => {
-//         setStats(data);
-//         setLoading(false);
-//       })
-//       .catch((err) => {
-//         setError(err.message);
-//         setLoading(false);
-//       });
-//   }, []);
-  const stats = {
-    gamesPlayed: 10,
-    correctGuesses: 7,
-    winningStreak: 3,
-    bestStreak: 5,
-  };
-  const loading = false;
-  const error = null;
-  const userId = 1;
+  useEffect(() => {
+    if (!userId) return;
+    fetch(`${API_BASE_URL}/stats/getStats?userId=${userId}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Stats not found');
+        return res.json();
+      })
+      .then((data) => {
+        setStats(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setLoading(false);
+      });
+  }, [userId]);
 
   if (loading) return <ActivityIndicator style={{ flex: 1 }} />;
   if (error) return <Text style={styles.error}>{error}</Text>;


### PR DESCRIPTION
**Dynamic Leaderboard Data**
Replaced hardcoded leaderboard data with a live fetch from the backend.

**Changes**
Connected leaderboard to GET /stats/getLeaderboard endpoint
Added EXPO_PUBLIC_API_BASE_URL env var usage instead of hardcoded URL
Updated LeaderboardEntry type to match the Stats entity response shape (user.name, bestStreak)

**Testing**
Verify leaderboard displays top 10 players by best streak on the home screen
Verify it falls back to localhost:8080 in local development