### PR TITLE
Test Fix, env Variable name fix

### DIFF
--- a/__tests__/game-test.tsx
+++ b/__tests__/game-test.tsx
@@ -36,6 +36,32 @@ jest.mock('react-native-paper', () => {
     };
 });
 
+global.fetch = jest.fn((url) => {
+    if (url.includes('/planes/getForGame')) {
+        return Promise.resolve({
+            text: () =>
+                Promise.resolve(JSON.stringify([
+                    { plane_id: 1, user_id: 1, name: 'Boeing 747' },
+                    { plane_id: 2, user_id: 1, name: 'Airbus A320' },
+                ])),
+        });
+    }
+
+    if (url.includes('/photos/getRandomByPlaneId')) {
+        return Promise.resolve({
+            json: () =>
+                Promise.resolve({
+                    photo_id: 1,
+                    user_id: 1,
+                    plane_id: 1,
+                    url: 'https://example.com/plane.jpg',
+                }),
+        });
+    }
+
+    return Promise.reject(new Error('Unknown URL'));
+}) as jest.Mock;
+
 describe('Game', () => {
     beforeEach(() => {
         const values = [0.1, 0.2, 0.3, 0.4, 0.5];

--- a/__tests__/index-test.tsx
+++ b/__tests__/index-test.tsx
@@ -19,7 +19,7 @@ describe('HomeScreen', () => {
     it('renders UI text', async () => {
         const {getByText} = render(<HomeScreen/>);
 
-        expect(await getByText('PlanespOtter ✈️')).toBeTruthy();
+        expect(await getByText('PlaneSpOtter ✈️')).toBeTruthy();
         expect(await getByText('Play Game')).toBeTruthy();
         expect(await getByText('Profile')).toBeTruthy();
         expect(await getByText('Top Players')).toBeTruthy();

--- a/app/(tabs)/game.tsx
+++ b/app/(tabs)/game.tsx
@@ -6,7 +6,7 @@ import {Image} from 'expo-image'
 import ScrollView = Animated.ScrollView;
 import {useAuth} from "@/lib/auth";
 
-const API_BASE_URL = process.env.EXPO_API_BASE_URL ?? 'http://localhost:8080';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:8080';
 
 interface Plane {
     plane_id: number;

--- a/app/(tabs)/photos.tsx
+++ b/app/(tabs)/photos.tsx
@@ -18,7 +18,7 @@ interface Photo {
     url: string;
 }
 
-const API_BASE_URL = process.env.EXPO_API_BASE_URL ?? 'http://localhost:8080';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:8080';
 
 const App = () => {
     const {token, user} = useAuth();


### PR DESCRIPTION
- All tests should be passing yet again
- Fixed EXPO_API_BASE_URL missing PUBLIC on the game and photos pages, which was causing our live deployment to not be able to fetch data on those pages. Should read EXPO_PUBLIC_API_BASE_URL now.